### PR TITLE
fix: Handle password hashes differently

### DIFF
--- a/backend/src/auth/routes.ts
+++ b/backend/src/auth/routes.ts
@@ -55,11 +55,7 @@ router.get("/me", ensureAuthenticated, async (req: Request, res: Response) => {
             return res.status(404).send({ message: "User was not found" });
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const returnValue: any = { ...user };
-        delete returnValue.password_hash;
-
-        return res.status(200).send(returnValue);
+        return res.status(200).send(user);
     } catch (e) {
         return res.status(500).send({
             message: "Error while fetching user",

--- a/backend/src/database/users.ts
+++ b/backend/src/database/users.ts
@@ -14,6 +14,14 @@ type DatabaseUser = {
     id: string;
     email: string;
     name: string;
+    created_at: Date;
+    modified_at: Date;
+}
+
+type DatabaseUserWithPasswordHash = {
+    id: string;
+    email: string;
+    name: string;
     password_hash: string;
     created_at: Date;
     modified_at: Date;
@@ -41,7 +49,7 @@ async function insertUser(user: CreateUser): Promise<boolean> {
     return true;
 }
 
-async function getUserByEmail(email: string): Promise<DatabaseUser | null> {
+async function getUserByEmail(email: string): Promise<DatabaseUserWithPasswordHash | null> {
     try {
         const result =
             await pool.query("SELECT * FROM users WHERE email = $1", [email]);
@@ -60,7 +68,7 @@ async function getUserByEmail(email: string): Promise<DatabaseUser | null> {
 async function getUserById(id: string): Promise<DatabaseUser | null> {
     try {
         const result =
-            await pool.query("SELECT * FROM users WHERE id = $1", [id]);
+            await pool.query("SELECT id, email, name, created_at, modified_at FROM users WHERE id = $1", [id]);
 
         if (result.rows.length <= 0)
             return null;


### PR DESCRIPTION
Previously, the application code would remove the password hash before returning the representation to the client. This has now entirely been removed from the SQL query where the password hash is not needed.